### PR TITLE
fix: project image size

### DIFF
--- a/components/Projects.js
+++ b/components/Projects.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Image from 'next/image';
 
 const ExternalLink = ({ href, children }) => (
   <a
@@ -14,18 +15,22 @@ const ExternalLink = ({ href, children }) => (
 const Project = ({ image, glink, link, title, description, index }) => {
   return (
     <div className="flex flex-wrap md:justify-between md:items-center">
-      <img
-        src={`${image}.webp`}
-        width="068px"
-        height="575px"
-        loading="lazy"
-        alt={title}
+      <div
         className={
           index
             ? 'w-full rounded shadow-xl md:w-6/12'
             : 'w-full rounded shadow-xl md:w-6/12 md:order-1'
         }
-      />
+      >
+        <Image
+          src={`${image}.webp`}
+          width="1572"
+          height="983"
+          sizes="(min-width:768px) 384px, 100vw"
+          alt={title}
+          layout="responsive"
+        />
+      </div>
       <div className="flex flex-col w-full mx-1 mt-3 mb-1 space-y-3 overflow-auto md:w-5/12 ">
         <a
           href={link}

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Image from 'next/image';
+import { theme } from '../lib/tailwind';
 
 const ExternalLink = ({ href, children }) => (
   <a
@@ -26,7 +27,7 @@ const Project = ({ image, glink, link, title, description, index }) => {
           src={`${image}.webp`}
           width="1572"
           height="983"
-          sizes="(min-width:768px) 384px, 100vw"
+          sizes={`(min-width:${theme.screens.md}) 384px, 100vw`}
           alt={title}
           layout="responsive"
         />

--- a/lib/tailwind.js
+++ b/lib/tailwind.js
@@ -1,0 +1,6 @@
+import resolveConfig from 'tailwindcss/resolveConfig';
+import tailwindConfig from '../tailwind.config.js';
+
+const fullConfig = resolveConfig(tailwindConfig);
+
+export const theme = fullConfig.theme;


### PR DESCRIPTION
Using the [Image component next/image](https://nextjs.org/docs/api-reference/next/image) to resize the project image as you are already using it on your about page. This will also handle the resizing and image formats. Older versions of iOS do not support `.webp` see [canisuse webp](https://www.caniuse.com/webp)

fix: `img` width & height match source image in `public/images` folder. As they are width 1572px and height 983px. 
FYI the html `img` element `width` & `height` should not have the `px` unit. `width="068px" should be `width="68"`.

feat: `sizes="(min-width:768px) 384px, 100vw"`, set the width for :md media query to `384px` to avoid larger images loading. `min-width` taken from [tailwindcss breakpoint docs](https://tailwindcss.com/docs/breakpoints) 